### PR TITLE
added detection for browser/server into _app.tsx -- web3react couldnt…

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,16 +11,23 @@ function getLibrary(provider) {
   return new ethers.providers.Web3Provider(provider) // this will vary according to whether you use e.g. ethers or web3.js
 }
 
-const Web3ReactProviderDefault = createWeb3ReactRoot(DefaultProviderName)
+// issue seems due to web3react provider trying to run on the server due to next's SSR
+// typeof window !== 'undefined' checks if code is on the browser or server
+// ternary checks to see if on browser or server and returns null if on server
+
+const Web3ReactProviderDefault =
+  typeof window !== 'undefined' && createWeb3ReactRoot(DefaultProviderName)
 
 const BanklessApp = ({ Component, pageProps }: AppProps) => {
   return (
     <Web3ReactProvider getLibrary={getLibrary}>
-      <Web3ReactProviderDefault getLibrary={getLibrary}>
-        <SiteLayout pageMeta={pageProps.pageMeta || { defaultPageMeta }}>
-          <Component {...pageProps} />
-        </SiteLayout>
-      </Web3ReactProviderDefault>
+      {typeof window !== 'undefined' ? (
+        <Web3ReactProviderDefault getLibrary={getLibrary}>
+          <SiteLayout pageMeta={pageProps.pageMeta || { defaultPageMeta }}>
+            <Component {...pageProps} />
+          </SiteLayout>
+        </Web3ReactProviderDefault>
+      ) : null}
     </Web3ReactProvider>
   )
 }


### PR DESCRIPTION
This pull request addresses the _Error: Invariant failed: A root already exists..._ error that is thrown when using `yarn dev` and references Issue #9 

![bankless-ssr-web3react-error](https://user-images.githubusercontent.com/9438776/117170627-2e65f480-ad98-11eb-826f-1d321a87106b.png)

Did some digging and this looks to be caused from Next.js running the `web3react` code on the server. Adding a ternary to detect whether the code is running on browser or server-side resolves this. By detecting the browser, the code in `_app.tsx` that relies on web3react's client-side context only runs in the browser and not the server. 

There is an open issue for this in the web3react repo and a similar fix was used, except with `process.browser` instead of `typeof window !== 'undefined'` - The Next.js team recommends against using `process.browser`

This change resolved the issue locally for me when using `yarn dev` and also when making live changes (seems to also resolve any hot reloading issues stemming from the SSR errors). 

I'm not 100% confident about what should be returned if the browser isn't detected -- right now the ternary is returning null so if the server is detected instead of the browser nothing is returned. Returning `<Component/>` also works, but including `<SiteLayout>...` breaks it since that seems to rely on the context provided by web3react.


