### PR TITLE
Fix for issue #61 where unclaimed tokens causes too many renders

### DIFF
--- a/src/components/global/Header/ConnectWalletButton.tsx
+++ b/src/components/global/Header/ConnectWalletButton.tsx
@@ -33,7 +33,6 @@ const WalletButton = () => {
   const [addressHidden, setAddressHidden] = useState(true)
   const [copiedAddress, setCopiedAddress] = useState(false)
   const [animateToken, setAnimateToken] = useState(false)
-  const [unclaimedTokens, setUnclaimedTokens] = useState(false)
   const [usingMetamask, setUsingMetamask] = useState(false)
 
   const router = useRouter()
@@ -116,13 +115,10 @@ const WalletButton = () => {
   const roundedBalance = trimCurrencyForWhales(rawBalance, 1)
 
   const claimData = useUserClaimData(walletAddress ?? '')
+  let unclaimedTokens = false
   claimData.forEach((individualClaimData) => {
-    if (
-      !unclaimedTokens &&
-      individualClaimData &&
-      !(individualClaimData as any).claimed
-    )
-      setUnclaimedTokens(true)
+    if (individualClaimData && !(individualClaimData as any).claimed)
+      unclaimedTokens = true
   })
 
   return (

--- a/src/components/global/Header/ConnectWalletButton.tsx
+++ b/src/components/global/Header/ConnectWalletButton.tsx
@@ -117,7 +117,11 @@ const WalletButton = () => {
 
   const claimData = useUserClaimData(walletAddress ?? '')
   claimData.forEach((individualClaimData) => {
-    if (individualClaimData && !(individualClaimData as any).claimed)
+    if (
+      !unclaimedTokens &&
+      individualClaimData &&
+      !(individualClaimData as any).claimed
+    )
       setUnclaimedTokens(true)
   })
 


### PR DESCRIPTION
### Overview

As mentioned in issue #61 users are getting an error when they are trying to claim $BANK.

### How to reproduce using any wallet

To do this we need to fake the claim's availability on Goerli. All it takes is a small modification to the `roots.json` to trick the website claim logic.

1. Open the [roots.json](https://github.com/BanklessDAO/bankless-dao-website/blob/b42bd8f1591170a21411093399b8b3abac710d5d/src/constants/roots.json) in your code editor. 
2. On lines `152132` and `152143` at the bottom of the file, replace `0xEC3281124d4c2FCA8A88e3076C1E7749CfEcb7F2` with **your own wallet address**  (see screenshot for the highlighted code).
3. Save the file.
4. Startup your local NextJS development server.
5. Switch your wallet to Goerli.
6. Open the local dev server in your browser and click "Connect".
7. This will result in the error mentioned in #61 

![CleanShot 2021-07-05 at 20 06 01](https://user-images.githubusercontent.com/81541283/124527910-71f6d200-ddcc-11eb-9c26-90421e7e7091.png)

### What caused this

After retracing the render steps of the Wallet Modal, I found out that too many re-renders were occurring in the `claimData.forEach` loop. It seems obvious now, but adding in a simple conditional was all it took to stop this from happening. You can see this change in the PR.

### Retrospective

I figured out how to properly test the logic for all of the claim data, by faking it in the `roots.json` mentioned above. This still doesn't test the actual contract execution, but it will at least check the "claim available" parts. Of course we should have learned this trick during the development phase, or at least made sure we could fully test claiming.

I shouldn't have missed the unprotected loop using state to trigger re-renders. Part of this code was carried over from the 2nd airdrop, when it was using the previous modal for total amount unclaimed. The previous version could use an unprotected loop because it didn't `useState` to update the total number. However the new modal uses the state of `unclaimedTokens` to add the "Unclaimed Tokens Available" message for users, which is why this happened.

Hopefully this fixes it!